### PR TITLE
Add lumentis folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,6 +170,8 @@ x64
 /test-report.md
 /test-report.json
 
+/.lumentis
+
 ########################### MY STUFF
 
 test


### PR DESCRIPTION
The `.lumentis` folder is not git ignored at the moment. This makes sure that that folder is not committed to Git.