### PR TITLE
Place Introduction subsection under main Introduction page

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -616,6 +616,13 @@ async function runWizard() {
     );
 
     if (outlineResponse.success) {
+      const outline : Outline = outlineResponse.response;
+      outline.sections.forEach((section) => {
+        if (section.permalink === 'introduction' || section.permalink === 'Introduction' || section.permalink === 'summary') {
+          section.permalink = 'index'
+        }
+
+      })
       wizardState.generatedOutline = outlineResponse.response;
     } else {
       console.log(


### PR DESCRIPTION
## The Problem

Currently there is a pretty common issue where sub-sections generated under the introduction are not attached to it in the sidebar:
<img width="281" alt="image" src="https://github.com/hrishioa/lumentis/assets/15617243/5aa7708a-d5f1-400b-b388-8def9d0d3772">

Ideally these would be  placed under the heading correctly like so:
<img width="314" alt="image" src="https://github.com/hrishioa/lumentis/assets/15617243/2bda8b02-f1f2-4b54-b044-f9964b44c8d6">


## Why it happens

This is because the introduction main section is called `index.mdx` and then the introduction sub-sections are in a folder called `introduction/`:
<img width="328" alt="image" src="https://github.com/hrishioa/lumentis/assets/15617243/fc3f0d09-da88-47e7-9167-4443df773ce5">

In order for next to display it properly, the folder name has to be the same as the main mdx file:
<img width="338" alt="image" src="https://github.com/hrishioa/lumentis/assets/15617243/196cc9ac-cda3-4beb-8a30-af11b8c177f9">
If the folder structure were like this, it would work.

## Current fix
I've just added in a pretty basic check for anything with 'introduction' as the permalink, and then replaces it with `index`. 

## Proper fix
However I think you can fix this properly in `page-generator.ts`, where it seems like you've already got a monkeypatch fix?

I see the TODO:
```typescript
    if (!metaJSON[permalink]) {
      // TODO: Need this damn monkeypatch because Nextra doesn't
      // seem to support nested pages at the top level
      metaJSON[permalink] = page.section.title;
```

And I think the answer is "Nextra **does** support nested pages at the top level, you just need to call the containing folder `index`. At least it works for me (see above). I think my monkeypatch will also somewhat work, but only if the toplevel folder is an `introduction`.



