### PR TITLE
Add OpenAI

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -12,6 +12,9 @@
   "linter": {
     "enabled": true,
     "rules": {
+      "suspicious": {
+        "noExplicitAny": "off"
+      },
       "recommended": true,
       "style": {
         "noUselessElse": "off",

--- a/package.json
+++ b/package.json
@@ -9,15 +9,16 @@
     "@anthropic-ai/tokenizer": "^0.0.4",
     "@inquirer/prompts": "^4.3.0",
     "cross-spawn": "^7.0.3",
+    "openai": "^4.47.1",
     "typescript": "^5.4.3",
     "youtube-transcript": "^1.1.0"
   },
   "devDependencies": {
     "@biomejs/biome": "latest",
     "@swc/core": "^1.4.8",
-    "@types/node": "^20.11.30",
     "@types/bun": "latest",
     "@types/cross-spawn": "^6.0.6",
+    "@types/node": "^20.11.30",
     "tsup": "^8.0.2"
   },
   "main": "dist/app.js",
@@ -29,7 +30,9 @@
     "package": "tsup",
     "check": "biome check --apply ."
   },
-  "files": ["dist"],
+  "files": [
+    "dist"
+  ],
   "type": "module",
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -30,9 +30,7 @@
     "package": "tsup",
     "check": "biome check --apply ."
   },
-  "files": [
-    "dist"
-  ],
+  "files": ["dist"],
   "type": "module",
   "peerDependencies": {
     "typescript": "^5.0.0"

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import Anthropic from "@anthropic-ai/sdk";
+import OpenAI from "openai";
 import { MessageParam } from "@anthropic-ai/sdk/resources";
 import { countTokens } from "@anthropic-ai/tokenizer";
 import {
@@ -12,21 +13,199 @@ import {
   getOutlineInferenceMessages,
   getPageGenerationInferenceMessages
 } from "./prompts";
-import { Outline } from "./types";
+import { AICallFailure, AICallResponse, AICallSuccess, AICallerOptions, Outline, genericMessageParam } from "./types";
 import { partialParse } from "./utils";
 
-export async function runClaudeInference(
+
+async function callAnthropic(
   messages: MessageParam[],
-  model: string,
-  maxOutputTokens: number,
-  apiKey?: string,
-  streamToConsole = false,
-  saveName?: string,
-  jsonType?: "parse" | "started_array" | "started_object",
-  saveToFilepath?: string,
-  prefix?: string,
-  continueOnPartialJSON?: boolean
-) {
+  options: AICallerOptions
+): Promise<AICallResponse> {
+  const {
+    maxOutputTokens,
+    apiKey,
+    streamToConsole,
+    saveToFilepath,
+    prefix,
+    jsonType,
+    systemPrompt,
+    model,
+  } = options;
+  console.log("Calling Anthropic")
+
+  if (jsonType === "started_object") {
+    messages.push({
+      role: "assistant",
+      content: "{",
+    });
+  } else if (jsonType === "started_array") {
+    messages.push({
+      role: "assistant",
+      content: "[",
+    });
+  }
+
+  let outputTokens = 0;
+  let inputTokens = 0;
+  let fullMessage = "";
+  let diffToFlush = 0;
+
+  const anthropic = apiKey ? new Anthropic({ apiKey }) : new Anthropic();
+
+
+  const response = await anthropic.messages.create({
+    messages,
+    model,
+    system: systemPrompt ? systemPrompt : "",
+    max_tokens: maxOutputTokens,
+    stream: true,
+  });
+
+  if (streamToConsole)
+    process.stdout.write(
+      `\n\nStreaming from ${model}${saveToFilepath ? ` to ${saveToFilepath}` : ""
+      }: `
+    );
+
+  for await (const chunk of response) {
+    const chunkText =
+      (chunk.type === "content_block_start" && chunk.content_block.text) ||
+      (chunk.type === "content_block_delta" && chunk.delta.text) ||
+      "";
+    if (chunk.type === "message_start")
+      inputTokens += chunk.message.usage.input_tokens;
+
+    if (chunk.type === "message_delta")
+      outputTokens += chunk.usage.output_tokens;
+
+
+    if (streamToConsole) process.stdout.write(chunkText);
+
+    fullMessage += chunkText;
+
+    if (saveToFilepath) {
+      diffToFlush += chunkText.length;
+
+      if (diffToFlush > 5000) {
+        diffToFlush = 0;
+        fs.writeFileSync(saveToFilepath, (prefix || "") + fullMessage);
+      }
+    }
+  }
+
+  if (jsonType === 'started_object')
+    fullMessage = "{" + fullMessage;
+  else if (jsonType === 'started_array')
+    fullMessage = "[" + fullMessage;
+  if (jsonType === 'started_object' || jsonType === 'started_array')
+    fullMessage = fullMessage.split("```")[0];
+  if (jsonType === "parse") {
+    const matchedJSON = fullMessage.match(/```json([\s\S]*?)```/g);
+    if (matchedJSON) {
+      fullMessage = matchedJSON[0]
+        .replace(/```json/g, "")
+        .replace(/```/g, "")
+        .trim();
+    }
+  }
+
+  return {
+    fullMessage,
+    outputTokens,
+    inputTokens,
+  }
+}
+
+// TODO: 
+// * Implement streaming. Doesn't look like OpenAI includes token usage in stream response object though, so that becomes complicated.
+// * `json_mode` doesn't really support continuance since it always returns proper JSON objects. Need to figure out how to handle that - json mode doesn't guarantee that it will actually finish the JSON object.
+async function callOpenAI(
+  messages: genericMessageParam[],
+  options: AICallerOptions
+): Promise<AICallResponse> {
+  const {
+    model,
+    maxOutputTokens,
+    streamToConsole,
+    saveToFilepath,
+    prefix,
+    systemPrompt,
+    jsonType
+  } = options;
+  console.log("Calling OpenAI")
+
+  const arrayWrapperPromptAddition = jsonType === "started_array" ? "Wrap the array in an object with the key `response`." : "";
+
+  if (systemPrompt) {
+    messages.unshift({
+      role: "system",
+      content: systemPrompt + arrayWrapperPromptAddition,
+    });
+  }
+
+
+  const openai = new OpenAI({ apiKey: process.env['OPENAI_API_KEY'] });
+
+  const completion = await openai.chat.completions.create({
+    messages,
+    model,
+    max_tokens: maxOutputTokens,
+    response_format: jsonType ? { type: "json_object" } : undefined,
+  });
+  let fullMessage = completion.choices[0].message.content || '';
+  const inputTokens = completion.usage?.prompt_tokens || 0; // I have no idea why usage can be undefined???
+  const outputTokens = completion.usage?.completion_tokens || 0;
+
+
+  if (streamToConsole) {
+    process.stdout.write(
+      `\n\nStreaming from ${model}${saveToFilepath ? ` to ${saveToFilepath}` : ""
+      }: `
+    );
+    process.stdout.write(fullMessage)
+  }
+  if (saveToFilepath) {
+    fs.writeFileSync(saveToFilepath, (prefix || "") + fullMessage);
+  }
+
+  if (jsonType === 'started_array') {
+    fullMessage = JSON.stringify(JSON.parse(fullMessage).response);
+  }
+
+
+  return { fullMessage, inputTokens, outputTokens }
+}
+
+// export async function runClaudeInference(
+//   messages: MessageParam[],
+//   model: string,
+//   maxOutputTokens: number,
+//   apiKey?: string,
+//   streamToConsole = false,
+//   saveName?: string,
+//   jsonType?: "parse" | "started_array" | "started_object",
+//   saveToFilepath?: string,
+//   prefix?: string,
+//   continueOnPartialJSON?: boolean
+// ) {
+  // note: should we call this caLLM for fun?
+export async function callLLM(
+  messages: MessageParam[],
+  options: AICallerOptions
+): Promise<AICallSuccess | AICallFailure> {
+  const {
+    provider,
+    model,
+    maxOutputTokens,
+    apiKey,
+    streamToConsole = false,  // Set default values here
+    saveName,
+    jsonType,
+    saveToFilepath,
+    prefix,
+    systemPrompt,
+    continueOnPartialJSON
+  } = options;
   const messageBackupSpot = path.join(lumentisFolderPath, MESSAGES_FOLDER);
 
   if (saveName) {
@@ -48,46 +227,26 @@ export async function runClaudeInference(
   }
 
   try {
-    const anthropic = apiKey ? new Anthropic({ apiKey }) : new Anthropic();
-    const response = await anthropic.messages.create({
-      messages,
-      model,
-      max_tokens: maxOutputTokens,
-      stream: true
-    });
-
-    let outputTokens = 0;
     let fullMessage = "";
-    let diffToFlush = 0;
-
-    if (streamToConsole)
-      process.stdout.write(
-        `\n\nStreaming from ${model}${
-          saveToFilepath ? ` to ${saveToFilepath}` : ""
-        }: `
+    let outputTokens = 0;
+    let inputTokens = 0;
+    if (provider === "openai") {
+      const OpenAIResp = await callOpenAI(
+        messages as genericMessageParam[],
+        options
       );
-
-    for await (const chunk of response) {
-      const chunkText =
-        (chunk.type === "content_block_start" && chunk.content_block.text) ||
-        (chunk.type === "content_block_delta" && chunk.delta.text) ||
-        "";
-
-      if (chunk.type === "message_delta")
-        outputTokens += chunk.usage.output_tokens;
-
-      if (streamToConsole) process.stdout.write(chunkText);
-
-      fullMessage += chunkText;
-
-      if (saveToFilepath) {
-        diffToFlush += chunkText.length;
-
-        if (diffToFlush > NUMBER_OF_CHARACTERS_TO_FLUSH_TO_FILE) {
-          diffToFlush = 0;
-          fs.writeFileSync(saveToFilepath, (prefix || "") + fullMessage);
-        }
-      }
+      fullMessage = OpenAIResp.fullMessage;
+      outputTokens = OpenAIResp.outputTokens;
+      inputTokens = OpenAIResp.inputTokens;
+    }
+    else if (provider === "anthropic") {
+      const AnthropResp = await callAnthropic(messages, options);
+      fullMessage = AnthropResp.fullMessage;
+      outputTokens = AnthropResp.outputTokens;
+      inputTokens = AnthropResp.inputTokens;
+    }
+    else {
+      throw new Error("Invalid provider");
     }
 
     if (streamToConsole) process.stdout.write("\n\n");
@@ -104,11 +263,9 @@ export async function runClaudeInference(
         }
       } else if (jsonType === "started_array") {
         fullMessage = "[" + fullMessage;
-
         fullMessage = fullMessage.split("```")[0];
       } else if (jsonType === "started_object") {
         fullMessage = "{" + fullMessage;
-
         fullMessage = fullMessage.split("```")[0];
       }
     }
@@ -145,25 +302,29 @@ export async function runClaudeInference(
         ];
 
         try {
-          const continuance = await runClaudeInference(
+          const continuance = await callLLM(
             newMessages,
-            model,
-            maxOutputTokens,
-            apiKey,
-            streamToConsole,
-            saveName,
-            undefined,
-            undefined,
-            undefined,
-            false
+            options = {
+              provider,
+              model,
+              maxOutputTokens,
+              apiKey,
+              streamToConsole,
+              saveName,
+              continueOnPartialJSON: false,
+            }
           );
 
           if (continuance.success === false) {
             const sortOfPartialJSON = partialParse(potentialPartialJSON);
             fullMessage = JSON.stringify(sortOfPartialJSON, null, 2);
+          } else {
+            fullMessage += continuance.message; // Not entirely sure about this one but I think it's needed?
+            outputTokens += continuance.outputTokens;
+            inputTokens += continuance.inputTokens || 0;
+            potentialPartialJSON += continuance.message;
           }
 
-          potentialPartialJSON += continuance.response;
         } catch (err) {
           console.error("Breaking because of error - ", err);
           break;
@@ -183,17 +344,39 @@ export async function runClaudeInference(
       fs.writeFileSync(saveToFilepath, (prefix || "") + fullMessage);
     }
 
+    // TODO: Add cost calculation
+    // const totalCost = getCallCostsWithTokens(inputTokens, outputTokens, provider, model)
+
+    // const cost = {
+    //   total: totalCost,
+    //   input: getCallCostsWithTokens(inputTokens, 0, provider, model),
+    //   output: getCallCostsWithTokens(0, outputTokens, provider, model)
+    // }
+
+
     return {
       success: true,
       outputTokens,
-      response: jsonType ? JSON.parse(fullMessage) : fullMessage
+      inputTokens,
+      // cost,
+      message: jsonType ? JSON.parse(fullMessage) : fullMessage
     };
   } catch (err) {
+    const errText = (err as Error).toString();
     console.error(err);
 
+    if (errText.toLowerCase().includes("rate limit") ||
+      errText.toLowerCase().includes("ratelimit")) {
+      return {
+        success: false,
+        rateLimited: true,
+        error: errText,
+      };
+    }
     return {
       success: false,
-      error: (err as Error).toString()
+      rateLimited: false,
+      error: errText,
     };
   }
 }
@@ -267,7 +450,7 @@ export const CLAUDE_PRIMARYSOURCE_BUDGET = (() => {
         permalink: "format-response-message",
         singleSentenceDescription:
           "Information on the formatResponseMessage utility function and its purpose.",
-          keythingsToCover: ["something", "something else"],
+        keythingsToCover: ["something", "something else"],
         disabled: false
       }
     ]

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -250,25 +250,6 @@ export async function callLLM(
     if (streamToConsole) process.stdout.write("\n\n");
 
     if (jsonType) {
-      if (jsonType === "parse") {
-        const matchedJSON = fullMessage.match(/```json([\s\S]*?)```/g);
-
-        if (matchedJSON) {
-          fullMessage = matchedJSON[0]
-            .replace(/```json/g, "")
-            .replace(/```/g, "")
-            .trim();
-        }
-      } else if (jsonType === "start_array") {
-        fullMessage = "[" + fullMessage;
-        fullMessage = fullMessage.split("```")[0];
-      } else if (jsonType === "start_object") {
-        fullMessage = "{" + fullMessage;
-        fullMessage = fullMessage.split("```")[0];
-      }
-    }
-
-    if (jsonType) {
       let potentialPartialJSON = fullMessage;
 
       do {

--- a/src/ai.ts
+++ b/src/ai.ts
@@ -128,6 +128,7 @@ async function callOpenAI(
     maxOutputTokens,
     streamToConsole,
     saveToFilepath,
+    apiKey,
     prefix,
     systemPrompt,
     jsonType
@@ -144,7 +145,7 @@ async function callOpenAI(
   }
 
 
-  const openai = new OpenAI({ apiKey: process.env['OPENAI_API_KEY'] });
+  const openai = apiKey ? new OpenAI({ apiKey }) : new OpenAI();
 
   const completion = await openai.chat.completions.create({
     messages,

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,11 +15,11 @@ import {
 } from "@inquirer/prompts";
 import {
   CLAUDE_PRIMARYSOURCE_BUDGET,
-  getClaudeCosts,
+  getCallCosts,
   callLLM
 } from "./ai";
 import {
-  CLAUDE_MODELS,
+  AI_MODELS_UI,
   EDITORS,
   LUMENTIS_FOLDER,
   RUNNERS,
@@ -90,14 +90,14 @@ async function runWizard() {
     message:
       "Pick a model for meta inference.\n Smarter is preferred, you can use a cheaper model for the actual writing later.",
     choices: [
-      ...CLAUDE_MODELS.map((model) => ({
+      ...AI_MODELS_UI.map((model) => ({
         name: model.name,
         value: model.model,
         description: model.smarterDescription
       })),
       new Separator()
     ],
-    default: wizardState.smarterModel || CLAUDE_MODELS[0].model
+    default: wizardState.smarterModel || AI_MODELS_UI[0].model
   });
 
   saveState(wizardState);
@@ -207,8 +207,7 @@ async function runWizard() {
         const testResponse = await callLLM(
           [{ role: "user", content: "What is your name?" }],
           {
-            provider: 'anthropic',
-            model: CLAUDE_MODELS[CLAUDE_MODELS.length - 1].model,
+            model: AI_MODELS_UI[AI_MODELS_UI.length - 1].model,
             maxOutputTokens: 10,
             apiKey: key || undefined
           }
@@ -224,7 +223,6 @@ async function runWizard() {
   // Ask for source description
 
   const baseOptions : AICallerOptions = {
-    provider: 'anthropic',
     model: wizardState.smarterModel,
     maxOutputTokens: 700,
     apiKey: wizardState.anthropicKey,
@@ -236,7 +234,7 @@ async function runWizard() {
   );
 
   const description = await input({
-    message: `Do you have a short description of your source?\n Who's talking, what type of content is it etc.\n (Leave empty to generate - costs $${getClaudeCosts(
+    message: `Do you have a short description of your source?\n Who's talking, what type of content is it etc.\n (Leave empty to generate - costs $${getCallCosts(
       descriptionInferenceMessages,
       700,
       wizardState.smarterModel
@@ -280,7 +278,7 @@ async function runWizard() {
   // Ask for title
 
   const title = await input({
-    message: `Do you have a short title or name?\n (Leave empty to generate - costs $${getClaudeCosts(
+    message: `Do you have a short title or name?\n (Leave empty to generate - costs $${getCallCosts(
       titleInferenceMessages,
       400,
       wizardState.smarterModel
@@ -355,7 +353,7 @@ async function runWizard() {
   );
 
   const themesFromUser = await input({
-    message: `Do you have any core themes or keywords about the source or the intended audience?\n (Leave empty to generate - costs $${getClaudeCosts(
+    message: `Do you have any core themes or keywords about the source or the intended audience?\n (Leave empty to generate - costs $${getCallCosts(
       themesInferenceMessages,
       400,
       wizardState.smarterModel
@@ -409,7 +407,7 @@ async function runWizard() {
   );
 
   const audienceFromUser = await input({
-    message: `Do you have any intended audience in mind?\n (Leave empty to generate - costs $${getClaudeCosts(
+    message: `Do you have any intended audience in mind?\n (Leave empty to generate - costs $${getCallCosts(
       audienceInferenceMessages,
       400,
       wizardState.smarterModel
@@ -469,7 +467,7 @@ async function runWizard() {
   const questionPermission = await confirm({
     message: `Are you okay ${
       wizardState.ambiguityExplained ? "re" : ""
-    }answering some questions about things that might not be well explained in the primary source?\n (Costs ${getClaudeCosts(
+    }answering some questions about things that might not be well explained in the primary source?\n (Costs ${getCallCosts(
       questionsMessages,
       2048,
       wizardState.smarterModel
@@ -575,7 +573,7 @@ async function runWizard() {
 
   if (!wizardState.generatedOutline || previousOutlineInvalidated) {
     const confirmOutline = await confirm({
-      message: `We're about to generate the outline (Costs $${getClaudeCosts(
+      message: `We're about to generate the outline (Costs $${getCallCosts(
         outlineQuestions,
         4096,
         wizardState.smarterModel
@@ -733,7 +731,7 @@ async function runWizard() {
     if (!wizardState.outlineComments) wizardState.outlineComments = "";
 
     const newSections = await input({
-      message: `Are there any sections you'd like to add or things to change? (Blank to accept, regneration costs ~${getClaudeCosts(
+      message: `Are there any sections you'd like to add or things to change? (Blank to accept, regneration costs ~${getCallCosts(
         regenerateOutlineInferenceMessages,
         4096,
         wizardState.smarterModel
@@ -854,16 +852,16 @@ async function runWizard() {
     wizardState.addDiagrams
   );
 
-  const costs = CLAUDE_MODELS.map((model) =>
+  const costs = AI_MODELS_UI.map((model) =>
     pageWritingMessages
-      .map((page) => getClaudeCosts(page.messages, 4096, model.model))
+      .map((page) => getCallCosts(page.messages, 4096, model.model))
       .reduce((a, b) => a + b, 0)
   );
 
   wizardState.pageGenerationModel = await select({
     message: `We can finally start writing our ${pageWritingMessages.length} pages! Pick a model to generate content: `,
     choices: [
-      ...CLAUDE_MODELS.map((model, index) => ({
+      ...AI_MODELS_UI.map((model, index) => ({
         name: model.name,
         value: model.model,
         description: `${model.pageDescription} (costs $${costs[index].toFixed(
@@ -874,7 +872,7 @@ async function runWizard() {
     ],
     default:
       wizardState.pageGenerationModel ||
-      CLAUDE_MODELS[CLAUDE_MODELS.length - 1].model
+      AI_MODELS_UI[AI_MODELS_UI.length - 1].model
   });
 
   saveState(wizardState);

--- a/src/app.ts
+++ b/src/app.ts
@@ -292,7 +292,7 @@ async function runWizard() {
     // note: changed maxtokens from 800 to 700, don't think the title needs more than the description
     const titleOptionsResponse = await callLLM(
       titleInferenceMessages,
-      { ...baseOptions, saveName: "title", jsonType: "started_array" }
+      { ...baseOptions, saveName: "title", jsonType: "start_array" }
     );
 
     if (titleOptionsResponse.success) {
@@ -366,7 +366,7 @@ async function runWizard() {
   } else {
     const themesOptionsResponse = await callLLM(
       themesInferenceMessages,
-      { ...baseOptions, saveName: "themes", jsonType: "started_array" }
+      { ...baseOptions, saveName: "themes", jsonType: "start_array" }
     );
 
     if (themesOptionsResponse.success) {
@@ -422,7 +422,7 @@ async function runWizard() {
   } else {
     const audienceOptionsResponse = await callLLM(
       audienceInferenceMessages,
-      { ...baseOptions, saveName: "audience", jsonType: "started_array" }
+      { ...baseOptions, saveName: "audience", jsonType: "start_array" }
     );
 
     if (audienceOptionsResponse.success) {
@@ -479,7 +479,7 @@ async function runWizard() {
   if (questionPermission) {
     const questionsResponse = await callLLM(
       questionsMessages,
-      { ...baseOptions, saveName: "questions", jsonType: "started_array", maxOutputTokens: 2048 } // overwrites maxOutputTokens
+      { ...baseOptions, saveName: "questions", jsonType: "start_array", maxOutputTokens: 2048 } // overwrites maxOutputTokens
     );
 
     if (questionsResponse.success) {
@@ -594,7 +594,7 @@ async function runWizard() {
       { 
         ...baseOptions, 
         saveName: "outline", 
-        jsonType: "started_object", 
+        jsonType: "start_object", 
         maxOutputTokens: 4096,
         continueOnPartialJSON: true 
       }
@@ -756,7 +756,7 @@ async function runWizard() {
         {
           ...baseOptions,
           saveName: "regenerateOutline",
-          jsonType: "started_object",
+          jsonType: "start_object",
           maxOutputTokens: 4096,
           continueOnPartialJSON: true
         }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,26 +11,87 @@ export const WRITING_STYLE_SIZE_LIMIT = 10000;
 export const MAX_HEADING_CHAR_LENGTH = 50;
 export const NUMBER_OF_CHARACTERS_TO_FLUSH_TO_FILE = 200;
 
-export const CLAUDE_MODELS = [
+
+
+// MUST UPDATE `AI_PROVIDERS` IN ai.ts WHEN NEW PROVIDER ADDED
+export const AI_MODELS_UI = [
   {
     name: "Claude 3 Opus",
+    provider: "anthropic",
     model: "claude-3-opus-20240229",
     smarterDescription: "This is the ferrari. Expensive but so good.",
     pageDescription: "Smartest - Use for expensive but awesome results!"
   },
   {
     name: "Claude 3 Sonnet",
+    provider: "anthropic",
     model: "claude-3-sonnet-20240229",
     smarterDescription: "Perfectly fine!",
     pageDescription: "Middle child - still kind of expensive"
   },
   {
     name: "Claude 3 Haiku",
+    provider: "anthropic",
     model: "claude-3-haiku-20240307",
     smarterDescription: "Cheapest, not preferred for this stage",
     pageDescription: "Fast and cheap - get what we pay for"
+  },
+  {
+    name: "OpenAI GPT-3.5 Turbo (1106)",
+    provider: "openai",
+    model: "gpt-3.5-turbo-1106",
+    tokenCountingModel: "gpt-3.5-turbo", // required bc OpenAI token counting is frustrating
+    smarterDescription: "Pretty cheap, good at JSON, bit dumb for the management stuff",
+    pageDescription: "Fast, cheap, lower rate limit than Claude"
+  },
+  {
+    name: "OpenAI GPT-4 Turbo",
+    provider: "openai",
+    model: "gpt-4-turbo-2024-04-09",
+    tokenCountingModel: "gpt-4", // required bc OpenAI token counting is frustrating
+    smarterDescription: "Bit expensive but smart",
+    pageDescription: "Good for high quality docs when you need to make a lot and are willing to pay"
   }
 ] as const;
+
+// MUST UPDATE `AI_PROVIDERS` IN ai.ts WHEN NEW PROVIDER ADDED
+export const AI_MODELS_INFO: Record<
+  string,
+  { 
+    provider: 'anthropic' | 'openai', 
+    tokenCountingModel?: string,
+    inputTokensPerM: number; 
+    outputTokensPerM
+  }
+> = {
+  'claude-3-opus-20240229': {
+    provider: "anthropic",
+    inputTokensPerM: 15,
+    outputTokensPerM: 75
+  },
+  'claude-3-sonnet-20240229': {
+    provider: "anthropic",
+    inputTokensPerM: 3,
+    outputTokensPerM: 15
+  },
+  'claude-3-haiku-20240307': {
+    provider: "anthropic",
+    inputTokensPerM: 0.25,
+    outputTokensPerM: 1.25
+  },
+  'gpt-4-turbo-2024-04-09': {
+    provider: "openai",
+    tokenCountingModel: "gpt-4", // required bc OpenAI token counting is frustrating
+    inputTokensPerM: 10,
+    outputTokensPerM: 30
+  },
+  'gpt-3.5-turbo-1106' : {
+    provider: "openai",
+    tokenCountingModel: "gpt-3.5-turbo", // required bc OpenAI token counting is frustrating
+    inputTokensPerM: 0.5,
+    outputTokensPerM: 1.5
+  }
+} as const;
 
 export const EDITORS = [
   { name: "nano", command: "nano" },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,8 +11,6 @@ export const WRITING_STYLE_SIZE_LIMIT = 10000;
 export const MAX_HEADING_CHAR_LENGTH = 50;
 export const NUMBER_OF_CHARACTERS_TO_FLUSH_TO_FILE = 200;
 
-
-
 // MUST UPDATE `AI_PROVIDERS` IN ai.ts WHEN NEW PROVIDER ADDED
 export const AI_MODELS_UI = [
   {
@@ -41,7 +39,8 @@ export const AI_MODELS_UI = [
     provider: "openai",
     model: "gpt-3.5-turbo-1106",
     tokenCountingModel: "gpt-3.5-turbo", // required bc OpenAI token counting is frustrating
-    smarterDescription: "Pretty cheap, good at JSON, bit dumb for the management stuff",
+    smarterDescription:
+      "Pretty cheap, good at JSON, bit dumb for the management stuff",
     pageDescription: "Fast, cheap, lower rate limit than Claude"
   },
   {
@@ -50,42 +49,43 @@ export const AI_MODELS_UI = [
     model: "gpt-4-turbo-2024-04-09",
     tokenCountingModel: "gpt-4", // required bc OpenAI token counting is frustrating
     smarterDescription: "Bit expensive but smart",
-    pageDescription: "Good for high quality docs when you need to make a lot and are willing to pay"
+    pageDescription:
+      "Good for high quality docs when you need to make a lot and are willing to pay"
   }
 ] as const;
 
 // MUST UPDATE `AI_PROVIDERS` IN ai.ts WHEN NEW PROVIDER ADDED
 export const AI_MODELS_INFO: Record<
   string,
-  { 
-    provider: 'anthropic' | 'openai', 
-    tokenCountingModel?: string,
-    inputTokensPerM: number; 
-    outputTokensPerM
+  {
+    provider: "anthropic" | "openai";
+    tokenCountingModel?: string;
+    inputTokensPerM: number;
+    outputTokensPerM;
   }
 > = {
-  'claude-3-opus-20240229': {
+  "claude-3-opus-20240229": {
     provider: "anthropic",
     inputTokensPerM: 15,
     outputTokensPerM: 75
   },
-  'claude-3-sonnet-20240229': {
+  "claude-3-sonnet-20240229": {
     provider: "anthropic",
     inputTokensPerM: 3,
     outputTokensPerM: 15
   },
-  'claude-3-haiku-20240307': {
+  "claude-3-haiku-20240307": {
     provider: "anthropic",
     inputTokensPerM: 0.25,
     outputTokensPerM: 1.25
   },
-  'gpt-4-turbo-2024-04-09': {
+  "gpt-4-turbo-2024-04-09": {
     provider: "openai",
     tokenCountingModel: "gpt-4", // required bc OpenAI token counting is frustrating
     inputTokensPerM: 10,
     outputTokensPerM: 30
   },
-  'gpt-3.5-turbo-1106' : {
+  "gpt-3.5-turbo-1106": {
     provider: "openai",
     tokenCountingModel: "gpt-3.5-turbo", // required bc OpenAI token counting is frustrating
     inputTokensPerM: 0.5,

--- a/src/page-generator.ts
+++ b/src/page-generator.ts
@@ -277,8 +277,8 @@ export async function generatePages(
     if (!wizardState.pageGenerationModel)
       throw new Error("No page generation model set");
 
-    const llmOptions : AICallerOptions = {
-      provider: 'anthropic',
+    const llmOptions: AICallerOptions = {
+      provider: "anthropic",
       model: wizardState.pageGenerationModel,
       maxOutputTokens: 4096,
       apiKey: wizardState.smarterApikey,
@@ -286,14 +286,10 @@ export async function generatePages(
       // systemPrompt?: string,
       saveName: `${page.levels.join(".")}.mdx`,
       saveToFilepath: pagePath,
-      prefix: `import { Callout, Steps, Step } from "nextra-theme-docs";\n\n`,
+      prefix: `import { Callout, Steps, Step } from "nextra-theme-docs";\n\n`
+    };
 
-    }
-
-    await callLLM(
-      page.messages,
-      llmOptions
-    );
+    await callLLM(page.messages, llmOptions);
   }
 
   console.log(

--- a/src/page-generator.ts
+++ b/src/page-generator.ts
@@ -281,7 +281,7 @@ export async function generatePages(
       provider: 'anthropic',
       model: wizardState.pageGenerationModel,
       maxOutputTokens: 4096,
-      apiKey: wizardState.anthropicKey,
+      apiKey: wizardState.smarterApikey,
       streamToConsole: wizardState.streamToConsole,
       // systemPrompt?: string,
       saveName: `${page.levels.join(".")}.mdx`,

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,5 +1,5 @@
 // import type { MessageParam } from "@anthropic-ai/sdk/resources";
-import { Outline, OutlineSection, GenericMessageParam } from "./types";
+import { GenericMessageParam, Outline, OutlineSection } from "./types";
 
 export function getTitleInferenceMessages(
   primarySource: string,

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,10 +1,10 @@
 // import type { MessageParam } from "@anthropic-ai/sdk/resources";
-import { Outline, OutlineSection, genericMessageParam } from "./types";
+import { Outline, OutlineSection, GenericMessageParam } from "./types";
 
 export function getTitleInferenceMessages(
   primarySource: string,
   description: string
-): genericMessageParam[] {
+): GenericMessageParam[] {
   return [
     // prettier-ignore
     {
@@ -27,7 +27,7 @@ Please generate up to 10 possible names for documentation we want to build, for 
 export function getAudienceInferenceMessages(
   primarySource: string,
   description: string
-): genericMessageParam[] {
+): GenericMessageParam[] {
   return [
     // prettier-ignore
     {
@@ -49,7 +49,7 @@ Please generate up to 10 words describing the intended audience for creating doc
 
 export function getThemeInferenceMessages(
   primarySource: string
-): genericMessageParam[] {
+): GenericMessageParam[] {
   return [
     // prettier-ignore
     {
@@ -69,7 +69,7 @@ Please generate up to 10 possible keywords referring to industries, technologies
 
 export function getDescriptionInferenceMessages(
   primarySource: string
-): genericMessageParam[] {
+): GenericMessageParam[] {
   return [
     // prettier-ignore
     {
@@ -88,7 +88,7 @@ export function getQuestionsInferenceMessages(
   primarySource: string,
   description: string,
   alreadyAnsweredQuestions?: string
-): genericMessageParam[] {
+): GenericMessageParam[] {
   return [
     // prettier-ignore
     {
@@ -119,10 +119,10 @@ We want to build proper comprehensive docs for what's in PrimarySource. Can you 
 }
 
 export function getOutlineRegenerationInferenceMessages(
-  outlineGenerationMessages: genericMessageParam[],
+  outlineGenerationMessages: GenericMessageParam[],
   selectedOutline: Outline,
   newSections: string
-): genericMessageParam[] {
+): GenericMessageParam[] {
   return [
     ...outlineGenerationMessages.slice(0, -1),
     {
@@ -151,7 +151,7 @@ export function getOutlineInferenceMessages(
   intendedAudience: string,
   ambiguityExplained?: string,
   writingExample?: string
-): genericMessageParam[] {
+): GenericMessageParam[] {
   return [
     // prettier-ignore
     {
@@ -253,11 +253,11 @@ Contents
 ];
 
 export function getPageGenerationInferenceMessages(
-  outlineGenerationMessages: genericMessageParam[],
+  outlineGenerationMessages: GenericMessageParam[],
   selectedOutline: Outline,
   selectedSection: OutlineSection,
   addDiagrams: boolean
-): genericMessageParam[] {
+): GenericMessageParam[] {
   const actualWritingGuidelines = addDiagrams
     ? [
         ...writingGuidelines.slice(

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,10 +1,10 @@
-import type { MessageParam } from "@anthropic-ai/sdk/resources";
-import { Outline, OutlineSection } from "./types";
+// import type { MessageParam } from "@anthropic-ai/sdk/resources";
+import { Outline, OutlineSection, genericMessageParam } from "./types";
 
 export function getTitleInferenceMessages(
   primarySource: string,
   description: string
-): MessageParam[] {
+): genericMessageParam[] {
   return [
     // prettier-ignore
     {
@@ -27,7 +27,7 @@ Please generate up to 10 possible names for documentation we want to build, for 
 export function getAudienceInferenceMessages(
   primarySource: string,
   description: string
-): MessageParam[] {
+): genericMessageParam[] {
   return [
     // prettier-ignore
     {
@@ -49,7 +49,7 @@ Please generate up to 10 words describing the intended audience for creating doc
 
 export function getThemeInferenceMessages(
   primarySource: string
-): MessageParam[] {
+): genericMessageParam[] {
   return [
     // prettier-ignore
     {
@@ -69,7 +69,7 @@ Please generate up to 10 possible keywords referring to industries, technologies
 
 export function getDescriptionInferenceMessages(
   primarySource: string
-): MessageParam[] {
+): genericMessageParam[] {
   return [
     // prettier-ignore
     {
@@ -88,7 +88,7 @@ export function getQuestionsInferenceMessages(
   primarySource: string,
   description: string,
   alreadyAnsweredQuestions?: string
-): MessageParam[] {
+): genericMessageParam[] {
   return [
     // prettier-ignore
     {
@@ -119,10 +119,10 @@ We want to build proper comprehensive docs for what's in PrimarySource. Can you 
 }
 
 export function getOutlineRegenerationInferenceMessages(
-  outlineGenerationMessages: MessageParam[],
+  outlineGenerationMessages: genericMessageParam[],
   selectedOutline: Outline,
   newSections: string
-): MessageParam[] {
+): genericMessageParam[] {
   return [
     ...outlineGenerationMessages.slice(0, -1),
     {
@@ -151,7 +151,7 @@ export function getOutlineInferenceMessages(
   intendedAudience: string,
   ambiguityExplained?: string,
   writingExample?: string
-): MessageParam[] {
+): genericMessageParam[] {
   return [
     // prettier-ignore
     {
@@ -253,11 +253,11 @@ Contents
 ];
 
 export function getPageGenerationInferenceMessages(
-  outlineGenerationMessages: MessageParam[],
+  outlineGenerationMessages: genericMessageParam[],
   selectedOutline: Outline,
   selectedSection: OutlineSection,
   addDiagrams: boolean
-): MessageParam[] {
+): genericMessageParam[] {
   const actualWritingGuidelines = addDiagrams
     ? [
         ...writingGuidelines.slice(

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,13 +11,13 @@ export type AICallerOptions = {
   streamToConsole?: boolean,
   systemPrompt?: string,
   saveName?: string,
-  jsonType?: "parse" | "started_array" | "started_object",
+  jsonType?: "parse" | "start_array" | "start_object",
   saveToFilepath?: string,
   prefix?: string,
   continueOnPartialJSON?: boolean
 }
 
-export type genericMessageParam = {
+export type GenericMessageParam = {
   role: 'user' | 'assistant' | 'system';
   content: string;
 }
@@ -68,7 +68,7 @@ export type Outline = {
 export type ReadyToGeneratePage = {
   section: OutlineSection;
   levels: string[];
-  messages: genericMessageParam[];
+  messages: GenericMessageParam[];
 };
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,10 @@
-import type { MessageParam } from "@anthropic-ai/sdk/resources";
 import { RUNNERS } from "./constants";
 
 
 // ________________________  AI TYPES  ________________________
 
 export type AICallerOptions = {
-  provider: 'anthropic' | 'openai',
+  // provider: 'anthropic' | 'openai',
   model: string,
   maxOutputTokens: number,
   apiKey?: string,
@@ -69,7 +68,7 @@ export type Outline = {
 export type ReadyToGeneratePage = {
   section: OutlineSection;
   levels: string[];
-  messages: MessageParam[];
+  messages: genericMessageParam[];
 };
 
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,56 @@
 import type { MessageParam } from "@anthropic-ai/sdk/resources";
 import { RUNNERS } from "./constants";
 
+
+// ________________________  AI TYPES  ________________________
+
+export type AICallerOptions = {
+  provider: 'anthropic' | 'openai',
+  model: string,
+  maxOutputTokens: number,
+  apiKey?: string,
+  streamToConsole?: boolean,
+  systemPrompt?: string,
+  saveName?: string,
+  jsonType?: "parse" | "started_array" | "started_object",
+  saveToFilepath?: string,
+  prefix?: string,
+  continueOnPartialJSON?: boolean
+}
+
+export type genericMessageParam = {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+}
+
+export type AICosts = {
+  input: number;
+  output: number;
+  total: number;
+}
+
+export type AICallSuccess = {
+  success: true;
+  outputTokens: number;
+  inputTokens?: number;
+  cost?: AICosts;
+  message: any;
+};
+
+export type AICallFailure = {
+  success: false;
+  rateLimited: boolean;
+  error: string;
+};
+
+export type AICallResponse = {
+  fullMessage: string;
+  outputTokens: number;
+  inputTokens: number;
+}
+
+// ##############################  DOCS OUTLINE  ##############################
+
 export type OutlineSection = LLMOutlineSection & { disabled?: boolean };
 
 export type LLMOutlineSection = {
@@ -22,6 +72,8 @@ export type ReadyToGeneratePage = {
   messages: MessageParam[];
 };
 
+
+// ##############################  WIZARD  ##############################
 export type WizardState = Partial<{
   gotDirectoryPermission: boolean;
   smarterModel: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,32 +1,31 @@
 import { RUNNERS } from "./constants";
 
-
 // ________________________  AI TYPES  ________________________
 
 export type AICallerOptions = {
   // provider: 'anthropic' | 'openai',
-  model: string,
-  maxOutputTokens: number,
-  apiKey?: string,
-  streamToConsole?: boolean,
-  systemPrompt?: string,
-  saveName?: string,
-  jsonType?: "parse" | "start_array" | "start_object",
-  saveToFilepath?: string,
-  prefix?: string,
-  continueOnPartialJSON?: boolean
-}
+  model: string;
+  maxOutputTokens: number;
+  apiKey?: string;
+  streamToConsole?: boolean;
+  systemPrompt?: string;
+  saveName?: string;
+  jsonType?: "parse" | "start_array" | "start_object";
+  saveToFilepath?: string;
+  prefix?: string;
+  continueOnPartialJSON?: boolean;
+};
 
 export type GenericMessageParam = {
-  role: 'user' | 'assistant' | 'system';
+  role: "user" | "assistant" | "system";
   content: string;
-}
+};
 
 export type AICosts = {
   input: number;
   output: number;
   total: number;
-}
+};
 
 export type AICallSuccess = {
   success: true;
@@ -46,7 +45,7 @@ export type AICallResponse = {
   fullMessage: string;
   outputTokens: number;
   inputTokens: number;
-}
+};
 
 // ##############################  DOCS OUTLINE  ##############################
 
@@ -56,7 +55,7 @@ export type LLMOutlineSection = {
   title: string;
   permalink: string;
   singleSentenceDescription: string;
-  keythingsToCover:string[];
+  keythingsToCover: string[];
   subsections?: OutlineSection[];
 };
 
@@ -70,7 +69,6 @@ export type ReadyToGeneratePage = {
   levels: string[];
   messages: GenericMessageParam[];
 };
-
 
 // ##############################  WIZARD  ##############################
 export type WizardState = Partial<{

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,7 +79,7 @@ export type WizardState = Partial<{
   streamToConsole: boolean;
   primarySourceFilename: string;
   loadedPrimarySource: string;
-  anthropicKey: string;
+  smarterApikey: string;
   description: string;
   title: string;
   coreThemes: string;
@@ -93,6 +93,7 @@ export type WizardState = Partial<{
   outlineComments: string;
   ignorePrimarySourceSize: boolean;
   pageGenerationModel: string;
+  pageGenerationApikey: string;
   addDiagrams: boolean;
   preferredRunnerForNextra: (typeof RUNNERS)[number]["command"];
   overwritePages: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,7 +55,6 @@ function getNonWhitespaceCharacterOfStringAt(
   };
 }
 
-// biome-ignore lint/suspicious/noExplicitAny: <explanation>
 export function partialParse(str: string): any {
   const tail: string[] = [];
   let i: number;
@@ -77,7 +76,7 @@ export function partialParse(str: string): any {
   if (tail[tail.length - 1] === "}") {
     // Ignore checking if the last key is an array:
     if (s[s.length - 1] !== "]") {
-      let insideLiteral = (s.split(/."/).length - 1) % 2 === 1 ? true : false; // If there are an odd number of double quotes, then we are in a string
+      let insideLiteral = (s.split(/."/).length - 1) % 2 === 1; // If there are an odd number of double quotes, then we are in a string
       let lastKV = "";
       let metAColon = false;
       let j: number;


### PR DESCRIPTION
# Reasoning

There's two major reasons to add additional providers to Lumentis:
1. It's always good to have additional providers as they have different strengths and user bases
2. Anthropic rate limits are killer and make Lumentis almost unusable to new users

# Methodology
This gives a wrapper `callLLM` function, which internally will use either `callAnthropic` or `callOpenAI`. 

## Wrapper
The `callLLM` wrapper is responsible for continuing on partial JSON if desired. This is not exactly relevant to `callOpenAI`, because OpenAI json mode doesn't allow for partial json in the response. However, structuring it in this way allows for us to add new providers which also need partial JSON continuance. 

The `callLLM` wrapper also handles saving messages and responses to files, since this should be done the same for all models.

## Specific functions
The specific provider calls handle:
* Adjusting for different JSON types
* Printing to console
* System prompts
* Counting tokens
* Actually calling the function

# First Commit summary

## Completed:
* Added OpenAI calling functionality (with json forcing)
* Moved option parameters to a dictionary

## Currently missing:
* Streaming
* Token and cost counting appropriate to different models
* Select OpenAI models from the Wizard
* Continue if not enough JSON in the OpenAI models
* Select different models (and add apikey if needed)

## Next Commit goals
* Select OpenAI models from the Wizard
