### PR TITLE
Fix anthropic error

### DIFF
--- a/src/ai.ts
+++ b/src/ai.ts
@@ -78,16 +78,22 @@ async function callAnthropic(
     continuing
   } = options;
 
+  let modifiedMessages = messages;
+
   if (jsonType === "start_object" && !continuing) {
-    messages.push({
-      role: "assistant",
-      content: "{"
-    });
+    modifiedMessages = messages.concat([
+      {
+        role: "assistant",
+        content: "{"
+      }
+    ]);
   } else if (jsonType === "start_array" && !continuing) {
-    messages.push({
-      role: "assistant",
-      content: "["
-    });
+    modifiedMessages = messages.concat([
+      {
+        role: "assistant",
+        content: "["
+      }
+    ]);
   }
 
   let outputTokens = 0;
@@ -98,7 +104,7 @@ async function callAnthropic(
   const anthropic = apiKey ? new Anthropic({ apiKey }) : new Anthropic();
 
   const response = await anthropic.messages.create({
-    messages: messages as MessageParam[],
+    messages: modifiedMessages as MessageParam[],
     model,
     system: systemPrompt ? systemPrompt : "",
     max_tokens: maxOutputTokens,


### PR DESCRIPTION
# Bugfix for Anthropic Page Generation

The previous push to include more providers introduced an error when using Anthropic for both outline creation and page generation:
<img width="1103" alt="image" src="https://github.com/hrishioa/lumentis/assets/15617243/3cccf365-3e24-4747-8e48-bdb0fd13a949">

### Cause of error
Immediate cause of this error was that there were two `assistant` messages in a row, which Anthropic doesn't permit:
<img width="299" alt="image" src="https://github.com/hrishioa/lumentis/assets/15617243/0f4eedbe-791b-485d-8e73-f4ff31529ebb">

The root cause of this error was that, specifically with Anthropic-created outlines, we were unintentionally adding two `assistant` messages:
1. When requesting the outline as JSON, we push `assistant: "{"` to the `outlineQuestions: GenericMessageParam[]` object
2. For the page generation, we then append `outlineQuestions` with the assistant response: `outlineQuestions.concat([{assistant: <assistantResponse>}])`. 

The combination of these two ends up with two `assistant` messages in a row.

This probably didn't show up in testing since it requires using anthropic for the outline generation (only model to append the `{`) and probably for the page generation too (other providers let multiple assistant messages through).

### The fix
To fix this I create a new variable `modifiedMessages` which handles the appending of  `assistant: "{"` when JSON is requested.

This avoids adding the first assistant message in (1) earlier, because this message is never pushed to the actual `outlineQuestions` - just to a temp variable.

### Testing successful
yes.
